### PR TITLE
Fix windows errors

### DIFF
--- a/src/apriltags3/bindings.py
+++ b/src/apriltags3/bindings.py
@@ -257,10 +257,12 @@ class Detector(object):
         self.params["debug"] = debug
 
         # detect OS to get extension for DLL
-        clib_ext_by_platform = {"Darwin": "dylib", "Linux": "so", "Windows": "dll"}
-        clib_ext = clib_ext_by_platform[platform.system()]
-
-        filename_pattern = f"libapriltag*.{clib_ext}"
+        filename_patterns_by_platform = {
+            "Darwin": "libapriltag*.dylib",
+            "Linux": "libapriltag*.so",
+            "Windows": "apriltag*.dll"
+        }
+        filename_pattern = filename_patterns_by_platform[platform.system()]
 
         self.libc = None
         self.tag_detector = None

--- a/src/apriltags3/bindings.py
+++ b/src/apriltags3/bindings.py
@@ -273,7 +273,7 @@ class Detector(object):
         )
         for hit in possible_hits:
             logger.debug(f"Testing possible hit: {hit}...")
-            self.libc = ctypes.CDLL(hit)
+            self.libc = ctypes.CDLL(str(hit))
             if self.libc:
                 logger.debug(f"Found working clib at {hit}")
                 break


### PR DESCRIPTION
The python wrapper would throw a couple of errors on windows due to differences in DLL handling.