### PR TITLE
Fix broken example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ The `Detector` class is a wrapper around the Apriltags functionality. You can in
 ```python
 from pupil_apriltags import Detector
 
-at_detector = Detector(searchpath=['apriltags'],
-                       families='tag36h11',
+at_detector = Detector(families='tag36h11',
                        nthreads=1,
                        quad_decimate=1.0,
                        quad_sigma=0.0,


### PR DESCRIPTION
We infer the searchpath now automatically.
Setting it manually will actually result in the wrapper not finding the apriltags shared library.