### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can of course clone the repository and build from there. For development you
 
 ```sh
 # clone the repository
-git clone https://github.com/pupil-labs/apriltags.git
+git clone --recursive https://github.com/pupil-labs/apriltags.git
 cd apriltags
 
 # install apriltags in editable mode with development requirements


### PR DESCRIPTION
Including the `--recursive` flag will ensure that the apriltags-source submodule is also checked out.  Failure to do so causes errors when compiling due to the submodule folder being empty.