### PR TITLE
Switch from pep517 to python-build

### DIFF
--- a/.travis/manylinux_build_wheel.sh
+++ b/.travis/manylinux_build_wheel.sh
@@ -6,8 +6,8 @@ export PATH=/opt/python/cp"$1"-cp"$1"m/bin:$PATH
 
 cd /io
 pip install -U pip
-pip install pep517
-python -m pep517.build .
+pip install build
+python -m build .
 
 for whl in /io/dist/*.whl; do
     auditwheel repair "$whl" --plat manylinux2010_x86_64 -w /io/dist/

--- a/.travis/manylinux_build_wheel.sh
+++ b/.travis/manylinux_build_wheel.sh
@@ -5,8 +5,8 @@ echo "Running manylinux_build_wheel for python" $1
 export PATH=/opt/python/cp"$1"-cp"$1"m/bin:$PATH
 
 cd /io
-pip install -U pip
-pip install build
+python -m pip install -U pip
+python -m pip install build
 python -m build .
 
 for whl in /io/dist/*.whl; do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "scikit-build",
-    "cmake==3.14.4", # 3.15 is missing wheels for mac and crashes on install
+    "cmake",
     "ninja",
     "pupil-pthreads-win"
 ]


### PR DESCRIPTION
Use [python-build](https://python-build.readthedocs.io/en/stable/index.html) instead of https://github.com/pypa/pep517 due to the [high-level interface being removed](https://github.com/pypa/pep517/pull/83).