### PR TITLE
Remove pinned cmake requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "scikit-build",
-    "cmake==3.14.4", # 3.15 is missing wheels for mac and crashes on install
+    "cmake",
     "ninja",
     "pupil-pthreads-win"
 ]


### PR DESCRIPTION
There is no need to pin CMake anymore since CMake has provided new releases with wheels for all platforms.