### PR TITLE
Allow apriltags to be installed with VS 2019

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if platform.system() == "Windows":
     # The Ninja cmake generator will use mingw (gcc) on windows travis instances, but we
     # need to use msvc for compatibility. The easiest solution I found was to just use
     # the vs cmake generator as it defaults to msvc.
-    cmake_args.append("-GVisual Studio 15 2017 Win64")
+    cmake_args.append("-GVisual Studio 16 2019 Win64")
     cmake_args.append("-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=True")
 
 with open("README.md") as f:


### PR DESCRIPTION
This argument actually fixed the version of visual studio to VS 2017, the best way is to remove this tag. But read from the comment above, it seems like some CI issue will happen if remove this argument. For now, it makes more sense if the default VS needed is 2019, and it's needed to be written in the readme to say "only VS 2019/2017 build tool can be used to install this package".