### PR TITLE
Update bindings.py to correct DLL search problem in Python 3.8 and above

### DIFF
--- a/src/pupil_apriltags/bindings.py
+++ b/src/pupil_apriltags/bindings.py
@@ -282,7 +282,7 @@ class Detector(object):
         )
         for hit in possible_hits:
             logger.debug(f"Testing possible hit: {hit}...")
-            self.libc = ctypes.CDLL(str(hit))
+            self.libc = ctypes.CDLL(str(hit), winmode=0)
             if self.libc:
                 logger.debug(f"Found working clib at {hit}")
                 break


### PR DESCRIPTION
Fixes the DLL search issue introduced in Python 3.8, as per https://stackoverflow.com/a/64472088/1832942.

Without this fix, running a simple detection such as `detector = apriltag.Detector(families='tagStandard41h12')` in Python 3.8 or above will produce the following error:

```
FileNotFoundError: Could not find module 'C:\Python39\lib\site-packages\pupil_apriltags\lib\apriltag.dll' (or one of its dependencies). Try using the full path with constructor syntax.
```
```