### PR TITLE
allowing detectors with multiple apriltag families

### DIFF
--- a/src/pupil_apriltags/bindings.py
+++ b/src/pupil_apriltags/bindings.py
@@ -359,49 +359,49 @@ class Detector:
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tag16h5"], 2
             )
-        elif "tag25h9" in self.params["families"]:
+        if "tag25h9" in self.params["families"]:
             self.libc.tag25h9_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tag25h9"] = self.libc.tag25h9_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tag25h9"], 2
             )
-        elif "tag36h11" in self.params["families"]:
+        if "tag36h11" in self.params["families"]:
             self.libc.tag36h11_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tag36h11"] = self.libc.tag36h11_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tag36h11"], 2
             )
-        elif "tagCircle21h7" in self.params["families"]:
+        if "tagCircle21h7" in self.params["families"]:
             self.libc.tagCircle21h7_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tagCircle21h7"] = self.libc.tagCircle21h7_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tagCircle21h7"], 2
             )
-        elif "tagCircle49h12" in self.params["families"]:
+        if "tagCircle49h12" in self.params["families"]:
             self.libc.tagCircle49h12_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tagCircle49h12"] = self.libc.tagCircle49h12_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tagCircle49h12"], 2
             )
-        elif "tagCustom48h12" in self.params["families"]:
+        if "tagCustom48h12" in self.params["families"]:
             self.libc.tagCustom48h12_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tagCustom48h12"] = self.libc.tagCustom48h12_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tagCustom48h12"], 2
             )
-        elif "tagStandard41h12" in self.params["families"]:
+        if "tagStandard41h12" in self.params["families"]:
             self.libc.tagStandard41h12_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tagStandard41h12"] = self.libc.tagStandard41h12_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tagStandard41h12"], 2
             )
-        elif "tagStandard52h13" in self.params["families"]:
+        if "tagStandard52h13" in self.params["families"]:
             self.libc.tagStandard52h13_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families["tagStandard52h13"] = self.libc.tagStandard52h13_create()
             self.libc.apriltag_detector_add_family_bits(
                 self.tag_detector_ptr, self.tag_families["tagStandard52h13"], 2
             )
-        else:
+        if len(self.tag_families) == 0:
             raise Exception("Unrecognized tag family name. Use e.g. 'tag36h11'.\n")
 
         # configure the parameters of the detector


### PR DESCRIPTION
`Bindings.py` calls `apriltag_detector_add_family_bits()` in a big else-if chain. Thus, after one tag family is added, the rest are skipped and detector objects can only have one Apriltag family. I assume this is a bug, otherwise `self.params["families"] = families.split()` (line 299) would make no sense.